### PR TITLE
Fix protocol (http->https) for Maven Central

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -34,7 +34,7 @@
 	<property name="hibernate-asciidoctor-theme.sourcedir" value="target/hibernate-asciidoctor-theme" />
 	<property name="downloaded-jars.dir" value="target/downloaded-jars" />
 	<property name="m2-repository.path" value="${user.home}/.m2/repository" />
-	<property name="maven-central.url" value="http://repo.maven.apache.org/maven2" />
+	<property name="maven-central.url" value="https://repo.maven.apache.org/maven2" />
 	<property name="maven-settings.path">settings-example.xml</property>
 	<property name="ci-user">jenkins</property>
 

--- a/settings-example.xml
+++ b/settings-example.xml
@@ -24,7 +24,7 @@
                 <repository>
                     <id>central</id>
                     <name>Maven Central</name>
-                    <url>http://repo.maven.apache.org/maven2/</url>
+                    <url>https://repo.maven.apache.org/maven2/</url>
                     <snapshots>
                         <enabled>false</enabled>
                         <updatePolicy>never</updatePolicy>
@@ -50,7 +50,7 @@
                 <pluginRepository>
                     <id>central</id>
                     <name>Maven Central</name>
-                    <url>http://repo.maven.apache.org/maven2/</url>
+                    <url>https://repo.maven.apache.org/maven2/</url>
                     <snapshots>
                         <enabled>false</enabled>
                         <updatePolicy>never</updatePolicy>


### PR DESCRIPTION
```
501 HTTPS Required.
Use https://repo.maven.apache.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
```
